### PR TITLE
Fix draft flag logic typo

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
-        if: ${{ steps.draft.outputs.value }} == 'true'
+        if: ${{ steps.draft.outputs.value }} == 'false'
         with:
           branch: gh-pages
           folder: dist


### PR DESCRIPTION
This PR fixes a mistake in GitHub Actions workflow that was causing the app to accidentally be deployed despite `"draft": true` being set in `package.json`.