### PR TITLE
Add date indicator for LoIs

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -37,7 +37,7 @@
   <link rel="shortcut icon" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon.ico">
   <meta name="apple-mobile-web-app-title" content="Tempo Lite">
   <link rel="manifest" href="site.webmanifest">
-  <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css"/>
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css"/>
   <title>Tempo Lite</title>
 </head>
 

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -113,7 +113,7 @@
         <hr style="border-color: grey;">
         
         <div id="locations-of-interest">
-          <h3 class="mb-1">Locations</h3>
+          <h3 class="mb-1">Locations for {{ radio==0 ? 'Nov 1' : radio==1 ? 'Nov 3' : 'Mar 28' }}</h3>
           <v-radio-group
             v-model="sublocationRadio"
             row


### PR DESCRIPTION
My local test users said they were confused by the location options changing. They didn't understand that they corresponded to specific dates, so I added the dates to the locations header.