### PR TITLE
Fixes for some accessibility issues

### DIFF
--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -332,7 +332,7 @@
         </p>
 
           <div class="d-flex flex-row justify-space-between">
-          <a>
+          <a tabindex="0">
             Credits
             <v-dialog
               id="credits-dialog"

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -219,6 +219,7 @@
               <v-radio
                 label="All Available Dates"
                 :value="0"
+                @keyup.enter="radio = 0"
               ></v-radio>
             </v-radio-group>
           </div>        
@@ -245,6 +246,7 @@
               <v-radio
                 label="November 1, 2023"
                 :value="1"
+                @keyup.enter="radio = 1"
               >
               </v-radio>
               <info-button>
@@ -264,6 +266,7 @@
               <v-radio
                 label="November 3, 2023"
                 :value="2"
+                @keyup.enter="radio = 2"
               ></v-radio>
               <info-button>
                 Levels of NO<sub>2</sub> change quickly from day to day, 
@@ -275,6 +278,7 @@
               <v-radio
                 label="March 28, 2024"
                 :value="3"
+                @keyup.enter="radio = 3"
               ></v-radio>
               <info-button>
                 Breathing air with a high concentration of NO<sub>2</sub>, 
@@ -306,6 +310,7 @@
               class="sublocation-radio"
               :label="loi.text"
               :value="index"
+              @keyup.enter="sublocationRadio = index"
             ></v-radio>
             <info-button>
               <p v-html="locationsOfInterestText[radio][index]"></p>


### PR DESCRIPTION
This PR fixes two of the issues from #37:
* Allow using enter to select the radio buttons
* Make the credits link be tab-focusable

In order to make the radio buttons enter-selectable, I had to add `keyup.enter` handlers to each button. It feels like there should be a simpler way to do this, but I didn't see anything in the Vuetify docs, so we can go with this.