### PR TITLE
Make calendar date match notable dates

### DIFF
--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -242,7 +242,7 @@
                 :transitions="false"
                 :format="(date: Date | null) => date?.toDateString()"
                 :preview-format="(date: Date | null) => date?.toDateString()"
-                dark
+                dark="true"
               ></date-picker>
             </v-radio-group>
           </div>        
@@ -1322,7 +1322,19 @@ export default defineComponent({
 }
 
 .dp__theme_dark {
-  --dp-primary-color: var(--accent-color) !important;
+  --dp-primary-text-color: #fff !important; // selected date text
+  --dp-primary-color: var(--accent-color)!important; // selected date background
+}
+
+.dp__month_year_select,
+.dp__calendar_item {
+  color: #97c8f1!important; // selectable date text & Month/Year
+  font-weight: 800 !important;
+}
+
+.dp__cell_disabled {
+  color: #888 !important;
+  font-weight: 400;
 }
 
 html {

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -1233,7 +1233,6 @@ export default defineComponent({
         
       }
     },
-    
 
     playing(play: boolean) {
       if (play) {
@@ -1283,7 +1282,9 @@ export default defineComponent({
         this.sublocationRadio = null;
         return;
       }
-      this.setNearestDate(this.datesOfInterest[value]?.getTime() ?? null);
+      const date = this.datesOfInterest[value] ?? this.singleDateSelected;
+      this.singleDateSelected = date;
+      this.setNearestDate(date.getTime());
       this.sublocationRadio = null;
     },
     


### PR DESCRIPTION
This PR adds a connection between the notable dates and the calendar picker. Now, whenever a notable date is selected, the date used for the calendar picker is updated to match.