### PR TITLE
Adds an alert for changes to the story

### DIFF
--- a/src/SnackbarAlert.vue
+++ b/src/SnackbarAlert.vue
@@ -1,0 +1,97 @@
+<script lang="ts">
+/**
+ * v-snackbar wrapper component. The message can be passed
+ * as a prop or as as the default slot. Props are passed
+ * through to v-snackbar.
+ * 
+ * Example Usage
+ * 
+ * <SnackbarAlert msg="Hello there" />
+ * 
+ * <SnackbarAlert msg="Hello there">
+ *  <template v-slot:activator="{ onClick, id }">
+ *   <v-btn :id="id" @click="onClick" color="primary">
+ *    Custom Activator
+ *   </v-btn>
+ *  </template>
+ * </SnackbarAlert>
+ * 
+ */
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: "SnackbarAlert",
+
+  props: {
+    msg: {
+      type: String || undefined || null,
+      required: false,
+      default: undefined,
+    },
+    hide: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+  },
+
+  data() {
+    return {
+      snackbar: false,
+      dialog: false,
+    };
+  },
+  
+  methods: {
+    openDialog() {
+      this.snackbar = true;
+      this.$nextTick(() => {
+        (this.$refs.snackbarMessage as HTMLElement).focus();
+      });
+    },
+    closeDialog() {
+      this.snackbar = false;
+      // make sure the focus goes back to the right place
+      this.$nextTick(() => {
+        this.$el.querySelector('#snackbar-activator')?.focus();
+        this.$el.querySelector('#snackbar-activator-slot')?.focus();
+      });
+    },
+  }
+
+});
+</script>
+
+<template>
+  <div class="cds-snackbar-alert ma-2" v-if="!hide">
+    
+    <slot name="activator" :onClick="openDialog" id="snackbar-activator-slot">
+      <v-btn @click="openDialog" color="#333" id="snackbar-activator" size="small">
+        <template v-slot:prepend>
+          <v-icon color="red" icon="mdi-alert-octagram"></v-icon>
+        </template>
+        Recent changes
+      </v-btn>
+    </slot>
+    
+    <v-snackbar 
+      v-model="snackbar" 
+      location="top center" 
+      v-bind="$attrs"
+      close-on-back
+      role="alert"
+      aria-live="assertive"
+      >
+      <span ref="snackbarMessage" tabindex="0" @keydown.esc="closeDialog">
+      <slot> {{ msg }} </slot>
+      </span>
+
+
+      <template v-slot:actions>
+        <v-btn tabindex="0" color="red" variant="text" @click="closeDialog">
+          Close
+        </v-btn>
+      </template>
+    </v-snackbar>
+  </div>
+</template>

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -127,6 +127,19 @@
 
       <h1 id="title">What is in the Air You Breathe?</h1>
       </div>
+      <snackbar-alert>
+        <ul>
+          <li> Images from Nov, 19<sup>th</sup> onward are created 
+            using the average, rather than the nearest pixel value 
+            when reprojecting. 
+          </li>
+        </ul>
+        <!-- <template v-slot:activator="{ onClick, id }">
+          <v-btn :id="id" @click="onClick" color="primary">
+            Custom Activator
+          </v-btn>
+        </template> -->
+      </snackbar-alert>
       <div id="where" class="big-label">where</div>
       <div id="map-container">
         <colorbar-horizontal
@@ -2210,5 +2223,19 @@ button:focus-visible,
   image-rendering: crisp-edges;               /* CSS4 Proposed  */
   image-rendering: pixelated;                 /* CSS4 Proposed  */
   -ms-interpolation-mode: nearest-neighbor;   /* IE8+           */
+}
+
+.cds-snackbar-alert {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  pointer-events: auto;
+  z-index: 999;
+}
+
+@media (max-width: 750px) {
+  .cds-snackbar-alert {
+    top: -1rem;
+  }
 }
 </style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import Vue, { createApp } from "vue";
 
 import { FundingAcknowledgement, IconButton, CreditLogos } from "@cosmicds/vue-toolkit";
@@ -7,6 +8,7 @@ import Colorbar from './ColorBar.vue';
 import ColorBarHorizontal from "./ColorBarHorizontal.vue";
 import InfoButton from "./InfoButton.vue";
 import vuetify from "../plugins/vuetify";
+import SnackbarAlert from "./SnackbarAlert.vue";
 
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
@@ -71,6 +73,7 @@ createApp(TempoLite, {})
   .component('info-button', InfoButton)
   .component('colorbar-horizontal', ColorBarHorizontal)
   .component('date-picker', VueDatePicker)
+  .component('snackbar-alert', SnackbarAlert)
 
   // Mount
   .mount("#app");


### PR DESCRIPTION
This adds a simple alert to inform users about changes to the story. In it's current presentation it is added/removed manually. But we could add a built in time limit (like only show for 7 days).

This will be useful to have once we the larger changes to how we display current events, or if we add features (like anciliary data layers, or links out to that days data on earthdata, etc)