### PR TITLE
disable tooltip for mobile

### DIFF
--- a/src/ShareButton.vue
+++ b/src/ShareButton.vue
@@ -4,7 +4,7 @@
     <v-snackbar 
       v-if="tooltipDisabled || alert"
       class="share-button-snackbar"   
-      timeout="4000" 
+      timeout="3500" 
       location="top" 
       activator="#share-button"
       text="Share link copied to clipboard. Paste to share this view!"
@@ -13,6 +13,7 @@
       min-height="0px"
       min-width="0px"
       transition="slide-y-transition"
+      close-on-content-click
       >
     </v-snackbar>
     <v-tooltip :disabled="tooltipDisabled" text="Share selected view">

--- a/src/ShareButton.vue
+++ b/src/ShareButton.vue
@@ -1,13 +1,13 @@
 
 <template>
-  <use-clipboard v-slot="{ copy, copied }" :source="source">
+  <use-clipboard v-slot="{ copy }" :source="source">
     <v-snackbar 
       v-if="tooltipDisabled || alert"
       class="share-button-snackbar"   
-      timeout="1000" 
+      timeout="4000" 
       location="top" 
       activator="#share-button"
-      text="Link Copied"
+      text="Share link copied to clipboard. Paste to share this view!"
       color="success"
       variant="flat"
       min-height="0px"
@@ -15,11 +15,11 @@
       transition="slide-y-transition"
       >
     </v-snackbar>
-    <v-tooltip :disabled="tooltipDisabled" :text="copied ? 'Link Copied' : 'Copy link to share view'">
+    <v-tooltip :disabled="tooltipDisabled" text="Share selected view">
       <template v-slot:activator="{ props }">
         <v-btn
           id="share-button"
-          aria-label="Copy link to share view"
+          aria-label="Get link to share selected view"
           class="share-button"
           icon
           @click="copy(source)"

--- a/src/ShareButton.vue
+++ b/src/ShareButton.vue
@@ -6,6 +6,7 @@
       class="share-button-snackbar"   
       timeout="1000" 
       location="top" 
+      activator="#share-button"
       text="Link Copied"
       color="success"
       variant="flat"
@@ -13,26 +14,11 @@
       min-width="0px"
       transition="slide-y-transition"
       >
-      <template v-slot:activator="{ props }">
-        <v-btn
-          aria-label="Copy link to share view"
-          class="share-button"
-          icon
-          @click="copy(source)"
-          @keyup.enter="copy(source)"
-          v-bind="props"
-          :color="buttonColor"
-          :elevation="elevation"
-          :size="size"
-          :rounded="rounded"
-        > 
-          <v-icon :color="iconColor">mdi-share-variant</v-icon>
-        </v-btn>
-      </template>
     </v-snackbar>
-    <v-tooltip v-if="!tooltipDisabled" :disabled="tooltipDisabled" :text="copied ? 'Link Copied' : 'Copy link to share view'">
+    <v-tooltip :disabled="tooltipDisabled" :text="copied ? 'Link Copied' : 'Copy link to share view'">
       <template v-slot:activator="{ props }">
         <v-btn
+          id="share-button"
           aria-label="Copy link to share view"
           class="share-button"
           icon

--- a/src/ShareButton.vue
+++ b/src/ShareButton.vue
@@ -1,7 +1,36 @@
 
 <template>
   <use-clipboard v-slot="{ copy, copied }" :source="source">
-    <v-tooltip :disabled="tooltipDisabled" :text="copied ? 'Link Copied' : 'Copy link to share view'">
+    <v-snackbar 
+      v-if="tooltipDisabled || alert"
+      class="share-button-snackbar"   
+      timeout="1000" 
+      location="top" 
+      text="Link Copied"
+      color="success"
+      variant="flat"
+      min-height="0px"
+      min-width="0px"
+      transition="slide-y-transition"
+      >
+      <template v-slot:activator="{ props }">
+        <v-btn
+          aria-label="Copy link to share view"
+          class="share-button"
+          icon
+          @click="copy(source)"
+          @keyup.enter="copy(source)"
+          v-bind="props"
+          :color="buttonColor"
+          :elevation="elevation"
+          :size="size"
+          :rounded="rounded"
+        > 
+          <v-icon :color="iconColor">mdi-share-variant</v-icon>
+        </v-btn>
+      </template>
+    </v-snackbar>
+    <v-tooltip v-if="!tooltipDisabled" :disabled="tooltipDisabled" :text="copied ? 'Link Copied' : 'Copy link to share view'">
       <template v-slot:activator="{ props }">
         <v-btn
           aria-label="Copy link to share view"
@@ -55,12 +84,22 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    alert: {
+      type: Boolean,
+      default: false,
+    },
     
+  },
+  
+  data() {
+    return {
+      snackbar: false,
+    };
   },
 });
 </script>
 
-<style scoped>
+<style>
 .share-button {
   z-index: 1000;
   background-color: rgb(255 255 255);
@@ -69,4 +108,9 @@ export default defineComponent({
   padding-inline: 5px;
   border-radius: 10px;
 }
+
+.share-button-snackbar .v-snackbar__wrapper > .v-snackbar__content {
+  padding: 0.75em 1em;
+}
+
 </style>

--- a/src/ShareButton.vue
+++ b/src/ShareButton.vue
@@ -1,7 +1,7 @@
 
 <template>
   <use-clipboard v-slot="{ copy, copied }" :source="source">
-    <v-tooltip :text="copied ? 'Link Copied' : 'Copy link to share view'">
+    <v-tooltip :disabled="tooltipDisabled" :text="copied ? 'Link Copied' : 'Copy link to share view'">
       <template v-slot:activator="{ props }">
         <v-btn
           aria-label="Copy link to share view"
@@ -50,6 +50,10 @@ export default defineComponent({
     rounded: {
       type: [String, Number],
       default: "1",
+    },
+    tooltipDisabled: {
+      type: Boolean,
+      default: false,
     },
     
   },

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -172,14 +172,14 @@
                 What's New
               </v-list-item>
               
-              <!-- <v-list-item 
+              <v-list-item 
                 tabindex="0"
                 aria-label="Show user guide"
-                @click="showUserGuide = true"
-                @keyup.enter="showUserGuide = true"
+                @click="() => {introSlide = 3; inIntro = true;}"
+                @keyup.enter="() => {introSlide = 3; inIntro = true;}"
                 >
                 User Guide
-              </v-list-item> -->
+              </v-list-item>
               
               <v-list-item 
                 tabindex="0" 

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -149,6 +149,7 @@
             size="small"
             rounded="1"
             :tooltip-disabled="mobile"
+            alert
           />
         <v-btn aria-role="menu" aria-label="Show menu" class="menu-button" variant="outlined" rounded="lg" color="yellow" elevation="5">
           <v-icon size="x-large">mdi-menu</v-icon>

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -175,8 +175,8 @@
               <v-list-item 
                 tabindex="0" 
                 aria-label="Show introduction"
-                @click="inIntro = true" 
-                @keyup.enter="inIntro = true" 
+                @click="() => {introSlide = 1; inIntro = true;}"
+                @keyup.enter="() => {introSlide = 1; inIntro = true;}"
                 >
                   Introduction
               </v-list-item>

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -60,7 +60,13 @@
                 </p>
                 <ul>
                   <li>
-                    Select a date and press the “Play” button or scroll the time slider to view the changing concentrations of NO<sub>2</sub> over North America on those dates. 
+                    Use the search box to navigate a location of your choice.
+                  </li>
+                  <li>
+                    Select a date and press the “Play” button or scroll the time slider to view the changing concentrations of NO<sub>2</sub> on those dates. 
+                  </li>
+                  <li>
+                    Click <v-icon style="color: #ffcc33">mdi-share-variant</v-icon> to share your selected location, date, and time with others.
                   </li>
                   <li v-bind:style="cssVars">
                     Press the <v-icon style="font-size: 1.3em; color: var(--accent-color)" elevation="1">mdi-information-variant-circle-outline</v-icon> button next to each Notable Date to get an overview of what to look for on that date
@@ -69,7 +75,7 @@
                     For each Notable Date, select one of two zoomed-in Locations to investigate specific pollution events.
                   </li>
                   <li>
-                    You can use the “Timezone” setting to investigate how pollution evolves over the day, for example as rush hour progresses in large cities.
+                    You can use the “Timezone” setting to investigate how pollution evolves over the day in different parts of the country, for example as rush hour progresses in large cities.
                   </li>
                 </ul>
                 <!-- add do not show introduction again button -->

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -171,6 +171,15 @@
                 >
                 What's New
               </v-list-item>
+
+              <v-list-item 
+                tabindex="0" 
+                aria-label="Show introduction"
+                @click="inIntro = true" 
+                @keyup.enter="inIntro = true" 
+                >
+                  Introduction
+              </v-list-item>
               
               <v-list-item 
                 tabindex="0"
@@ -179,15 +188,6 @@
                 @keyup.enter="() => {introSlide = 3; inIntro = true;}"
                 >
                 User Guide
-              </v-list-item>
-              
-              <v-list-item 
-                tabindex="0" 
-                aria-label="Show introduction"
-                @click="inIntro = true" 
-                @keyup.enter="inIntro = true" 
-                >
-                  Introduction
               </v-list-item>
               
               <v-list-item 

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -148,6 +148,7 @@
             elevation="0"
             size="small"
             rounded="1"
+            :tooltip-disabled="mobile"
           />
         <v-btn aria-role="menu" aria-label="Show menu" class="menu-button" variant="outlined" rounded="lg" color="yellow" elevation="5">
           <v-icon size="x-large">mdi-menu</v-icon>


### PR DESCRIPTION
@Carifio24 helped me set up this disabling of the share button tooltip on mobile, and suggested that we add a snackbar or some other notification that explains what to do, otherwise there is no visible cue without the tooltip. @johnarban, can you please add that?