### PR TITLE
hide focus visible style for intro

### DIFF
--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -2200,7 +2200,7 @@ i.mdi-menu-down {
 }
 
 // From Sara Soueidan (https://www.sarasoueidan.com/blog/focus-indicators/) & Erik Kroes (https://www.erikkroes.nl/blog/the-universal-focus-state/)
-:focus-visible:not(.v-field__input input),
+:focus-visible:not(.v-field__input input, .v-overlay__content),
 button:focus-visible,
 .focus-visible,
 .v-selection-control--focus-visible .v-selection-control__input {


### PR DESCRIPTION
This PR hides excludes `.v-overlay__content` from `:focus-visible` styling. 