### PR TITLE
This adds basic Esri ImageServer Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ tsconfig.tsbuildinfo
 */.DS_Store
 */*/.DS_Store
 .vscode/settings.json
+.vscode/launch.json
 
 **/tests_output/**
 

--- a/package.json
+++ b/package.json
@@ -11,8 +11,10 @@
     "@wwtelescope/engine-pinia": "^0.9.0",
     "date-fns": "^3.6.0",
     "date-fns-tz": "^3.1.3",
+    "esri-leaflet": "^3.0.17",
     "leaflet": "^1.9.4",
     "leaflet.zoomhome": "^1.0.0",
+    "mapbox-gl-esri-sources": "^0.0.7",
     "maplibre-gl": "^5.5.0",
     "uuid": "^11.1.0",
     "vue": "^3.4.15",
@@ -20,6 +22,7 @@
     "webpack-plugin-vuetify": "^2.0.0"
   },
   "devDependencies": {
+    "@types/esri-leaflet": "^3.0.3",
     "@types/leaflet": "^1.9.11",
     "@typescript-eslint/eslint-plugin": "^6.19.0",
     "@typescript-eslint/parser": "^6.19.0",

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -954,8 +954,16 @@ import { usezoomhome} from './composables/leaflet/useZoomHome';
 import { useImageOverlay } from "./composables/leaflet/useImageOverlay";
 import { useFieldOfRegard} from "./composables/leaflet/useFieldOfRegard";
 import { useLocationMarker } from "./composables/leaflet/useMarker";
+import { useEsriLayer } from "./esri/leaflet/useEsriImageLayer";
 const zoomScale = 1; 
 
+// Import maplibre Composables
+// import { useMap } from "./composables/maplibre/useMap";
+// import { usezoomhome} from './composables/maplibre/useZoomHome';
+// import { useImageOverlay } from "./composables/maplibre/useImageOverlay";
+// import { useFieldOfRegard} from "./composables/maplibre/useFieldOfRegard";
+// import { useLocationMarker } from "./composables/maplibre/useMarker";
+// import { useEsriLayer } from "./esri/maplibre/useEsriImageLayer";
 // const zoomScale = 0.5; // for matplibre-gl
 
 
@@ -1293,7 +1301,12 @@ const imageName = computed(() => {
   return getTempoFilename(date.value);
 });
 
+const showImage = ref(false);
 const imageUrl = computed(() => {
+  if (!showImage.value) {
+    return '';
+  }
+  
   if (customImageUrl.value) {
     return customImageUrl.value;
   }
@@ -1356,11 +1369,21 @@ const showingExtendedRange = computed(() => {
 });
 
 
+const {getEsriTimeSteps, addEsriSource} = useEsriLayer(
+  "https://gis.earthdata.nasa.gov/image/rest/services/C2930763263-LARC_CLOUD/TEMPO_NO2_L3_V03_HOURLY_TROPOSPHERIC_VERTICAL_COLUMN/ImageServer",
+  "NO2_Troposphere",
+  timestamp,
+  opacity,
+);
+getEsriTimeSteps();
+  
+  
 
 
 const onMapReady = (map) => {
   map.on('moveend', updateURL);
   map.on('zoomend', updateURL);
+  addEsriSource(map);
 };
 const showRoads = ref(true);
 const { map, createMap, setView } = useMap("map", initState.value, showRoads, onMapReady);

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -954,7 +954,7 @@ import { usezoomhome} from './composables/leaflet/useZoomHome';
 import { useImageOverlay } from "./composables/leaflet/useImageOverlay";
 import { useFieldOfRegard} from "./composables/leaflet/useFieldOfRegard";
 import { useLocationMarker } from "./composables/leaflet/useMarker";
-import { useEsriLayer } from "./esri/leaflet/useEsriImageLayer";
+// import { useEsriLayer } from "./esri/leaflet/useEsriImageLayer";
 const zoomScale = 1; 
 
 // Import maplibre Composables
@@ -964,6 +964,7 @@ const zoomScale = 1;
 // import { useFieldOfRegard} from "./composables/maplibre/useFieldOfRegard";
 // import { useLocationMarker } from "./composables/maplibre/useMarker";
 // import { useEsriLayer } from "./esri/maplibre/useEsriImageLayer";
+// import { useEsriLayer } from "./esri/maplibre/useEsriImageLayerPlain"; // do not use
 // const zoomScale = 0.5; // for matplibre-gl
 
 
@@ -1301,7 +1302,7 @@ const imageName = computed(() => {
   return getTempoFilename(date.value);
 });
 
-const showImage = ref(false);
+const showImage = ref(true);
 const imageUrl = computed(() => {
   if (!showImage.value) {
     return '';
@@ -1369,13 +1370,13 @@ const showingExtendedRange = computed(() => {
 });
 
 
-const {getEsriTimeSteps, addEsriSource} = useEsriLayer(
-  "https://gis.earthdata.nasa.gov/image/rest/services/C2930763263-LARC_CLOUD/TEMPO_NO2_L3_V03_HOURLY_TROPOSPHERIC_VERTICAL_COLUMN/ImageServer",
-  "NO2_Troposphere",
-  timestamp,
-  opacity,
-);
-getEsriTimeSteps();
+// const {getEsriTimeSteps, addEsriSource} = useEsriLayer(
+//   "https://gis.earthdata.nasa.gov/image/rest/services/C2930763263-LARC_CLOUD/TEMPO_NO2_L3_V03_HOURLY_TROPOSPHERIC_VERTICAL_COLUMN/ImageServer",
+//   "NO2_Troposphere",
+//   timestamp,
+//   opacity,
+// );
+// getEsriTimeSteps();
   
   
 
@@ -1383,7 +1384,7 @@ getEsriTimeSteps();
 const onMapReady = (map) => {
   map.on('moveend', updateURL);
   map.on('zoomend', updateURL);
-  addEsriSource(map);
+  // addEsriSource(map);
 };
 const showRoads = ref(true);
 const { map, createMap, setView } = useMap("map", initState.value, showRoads, onMapReady);

--- a/src/esri/ImageLayerConfig.ts
+++ b/src/esri/ImageLayerConfig.ts
@@ -1,0 +1,125 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+// import L from 'leaflet';
+// import * as esri from 'esri-leaflet';
+
+// const earthdataRestSerivceURL = "https://gis.earthdata.nasa.gov/image/rest/services/C2930763263-LARC_CLOUD/TEMPO_NO2_L3_V03_HOURLY_TROPOSPHERIC_VERTICAL_COLUMN/ImageServer";
+import { type ImageMapLayer } from 'esri-leaflet';
+
+type ColorRamps = "Magma" | "Inferno" | "Plasma" | "Viridis" | "Gray" | "Hillshade";
+
+type PixelType = Parameters<ImageMapLayer['setPixelType']>[0];
+
+interface RasterFunctionObject {
+  rasterFunction: string;
+  variableName?: string; // Optional, as it might be implied or set by composition
+  rasterFunctionArguments?: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [key: string]: any;
+    Raster?: RasterFunctionObject | { variableName: string }; // Input can be another function or the base 'Raster'
+  };
+  outputPixelType?: PixelType;
+}
+
+// https://developers.arcgis.com/rest/services-reference/enterprise/raster-function-objects/
+// https://developers.arcgis.com/rest/services-reference/enterprise/raster-function-objects/#resample
+const _stretchRule: RasterFunctionObject = {
+  'rasterFunction': 'Stretch',
+  'outputPixelType': 'U8' as PixelType, 
+  'variableName': 'Raster',
+  'rasterFunctionArguments': {
+    'StretchType': 5,
+    'Statistics': [[
+      100000000000000, // max
+      15000000000000000, // min
+      0,0
+    ]],
+    'DRA': false,
+    'UseGamma': false,
+    'Gamma': [1],
+    'ComputeGamma': true,
+    'Min': 255,
+    'Max': 0
+  },
+};
+  
+const _colorMapRule: RasterFunctionObject = {
+  'rasterFunction': 'Colormap',
+  'variableName': 'Raster',
+  'rasterFunctionArguments': {
+    'ColormapName': "Magma" as ColorRamps,
+  },
+};
+
+const _resampleRule: RasterFunctionObject =  {
+  'rasterFunction': 'Resample',
+  'variableName': 'Raster',
+  'rasterFunctionArguments': {
+    'ResamplingType': '0', // Nearest Neighbor
+  },
+};
+
+
+export function composeRasterRules(
+  baseRule: RasterFunctionObject,
+  additionalRules: RasterFunctionObject[]
+): RasterFunctionObject {
+  let currentRule: RasterFunctionObject = { ...baseRule }; 
+
+  
+  for (let i = 0; i < additionalRules.length; i++) {
+    const nextOuterRule = { ...additionalRules[i] }; // Copy to avoid modifying original rule objects
+
+    // Ensure rasterFunctionArguments exists
+    if (!nextOuterRule.rasterFunctionArguments) {
+      nextOuterRule.rasterFunctionArguments = {};
+    }
+
+    // Assign the current (inner) rule as the 'Raster' input to the next outer rule.
+    nextOuterRule.rasterFunctionArguments.Raster = currentRule;
+
+    currentRule = nextOuterRule; // The newly composed rule becomes the current one for the next iteration
+  }
+
+  return currentRule;
+}
+
+export const renderingRule = composeRasterRules(_stretchRule, [_colorMapRule, _resampleRule]);
+
+
+
+interface MultidimensionalDefinition {
+  variableName: string;
+  dimensionName: string;
+  values: number[];
+}
+
+export interface EsriSlice {
+  sliceId: number;
+  multidimensionalDefinition: MultidimensionalDefinition[];
+}
+
+export interface EsriSliceResponse {
+  slices: EsriSlice[];
+}
+
+
+export type VariableNames = 'NO2_Troposphere' ;
+
+export async function fetchEsriTimeSteps(esriUrl: string, variableName: VariableNames, dimensionName = "StdTime"): Promise<EsriSliceResponse> {
+  const url = esriUrl + '/slices';
+  const format = "json";
+  const multidimensionalDefinition = { variableName: variableName, dimensionName: dimensionName };
+  const params = { f: format, multidimensionalDefinition: JSON.stringify(multidimensionalDefinition) };
+  const fetchURL = new URL(url);
+  fetchURL.search = new URLSearchParams(params).toString();
+  return fetch(fetchURL).then(res => {
+    return res.json();
+  });
+}
+
+
+export function extractTimeSteps(data: EsriSliceResponse) {
+  const slices = data.slices;
+  const timesteps = slices.map(slice => slice.multidimensionalDefinition[0].values[0]);
+  return timesteps;
+}

--- a/src/esri/ImageLayerConfig.ts
+++ b/src/esri/ImageLayerConfig.ts
@@ -22,7 +22,7 @@ interface RasterFunctionObject {
 
 // https://developers.arcgis.com/rest/services-reference/enterprise/raster-function-objects/
 // https://developers.arcgis.com/rest/services-reference/enterprise/raster-function-objects/#resample
-const _stretchRule: RasterFunctionObject = {
+export const _stretchRule: RasterFunctionObject = {
   'rasterFunction': 'Stretch',
   'outputPixelType': 'U8' as PixelType, 
   'variableName': 'Raster',
@@ -42,7 +42,7 @@ const _stretchRule: RasterFunctionObject = {
   },
 };
   
-const _colorMapRule: RasterFunctionObject = {
+export const _colorMapRule: RasterFunctionObject = {
   'rasterFunction': 'Colormap',
   'variableName': 'Raster',
   'rasterFunctionArguments': {
@@ -50,7 +50,7 @@ const _colorMapRule: RasterFunctionObject = {
   },
 };
 
-const _resampleRule: RasterFunctionObject =  {
+export const _resampleRule: RasterFunctionObject =  {
   'rasterFunction': 'Resample',
   'variableName': 'Raster',
   'rasterFunctionArguments': {

--- a/src/esri/leaflet/useEsriImageLayer.ts
+++ b/src/esri/leaflet/useEsriImageLayer.ts
@@ -1,0 +1,99 @@
+// src/composables/useEsriLayer.ts
+import { ref, watch, nextTick, MaybeRef, toRef, Ref } from 'vue';
+import { ImageMapLayer, imageMapLayer } from 'esri-leaflet';
+import { renderingRule, fetchEsriTimeSteps, extractTimeSteps, type VariableNames } from '../ImageLayerConfig';
+import { Map } from 'leaflet';
+export const no2Url = ref('https://gis.earthdata.nasa.gov/image/rest/services/C2930763263-LARC_CLOUD/TEMPO_NO2_L3_V03_HOURLY_TROPOSPHERIC_VERTICAL_COLUMN/ImageServer');
+
+
+
+export function useEsriLayer(url: string, variableName: VariableNames, timestamp: Ref<number>, opacity: MaybeRef<number>) {
+  let esriTimesteps: number[] = [];
+  const esriImageLayer = ref(null as ImageMapLayer | null);
+
+  const opacityRef = toRef(opacity);
+
+  const noEsriData = ref(false);
+
+
+
+  async function getEsriTimeSteps() {
+    fetchEsriTimeSteps(url, variableName)
+      .then((json) => {
+        esriTimesteps = extractTimeSteps(json);
+        nextTick(updateEsriTimeRange);
+      });
+  }
+
+
+  function updateEsriTimeRange() {
+    const now = timestamp.value;
+    if (esriTimesteps.length === 0) {
+      console.warn('No ESRI time steps available');
+      return;
+    }
+    
+    const nearest = esriTimesteps.reduce((a, b) => Math.abs(b - now) < Math.abs(a - now) ? b : a);
+    noEsriData.value = Math.abs((nearest - now) / (1000 * 60)) > 60;
+    if (noEsriData.value) {
+      console.error('nearest time is more than an hour away');
+    }
+    if (esriImageLayer.value) {
+      // Esri will pick the first valid time slice
+      // console.table({'nearest': new Date(nearest), 'now': new Date(now), 'diff (minutes)': (nearest - now) / (1000 * 60) });
+      esriImageLayer.value.setTimeRange(new Date(nearest), new Date(nearest * 2));
+    }
+  }
+
+  function updateEsriOpacity(value: number = 0.8) {
+    if (esriImageLayer.value) {
+      esriImageLayer.value.setOpacity(value);
+    }
+  }
+
+
+  esriImageLayer.value = imageMapLayer({
+    url: url,
+    format: 'png',
+    opacity: opacityRef.value ?? 0.8,
+  });
+  
+  if (esriImageLayer.value) {
+    // esriImageLayer.value.setPixelType(renderingRule?.rasterFunctionArguments?.Raster?.outputPixelType ?? 'U8');
+    esriImageLayer.value.setRenderingRule(renderingRule);
+    updateEsriTimeRange();
+  }
+
+
+  function addEsriSource(map: Map) {
+    if (!map) return;
+    esriImageLayer.value?.addTo(map);
+  }
+
+  watch(timestamp, (_value: number) => {
+    updateEsriTimeRange();
+  }, { immediate: true });
+
+  watch(opacityRef, (value: number) => {
+    updateEsriOpacity(value);
+  });
+
+  watch(noEsriData, (value: boolean) => {
+    if (value) {
+      updateEsriOpacity(0);
+    } else {
+      updateEsriOpacity(opacityRef.value);
+    }
+  });
+
+  return {
+    esriImageLayer,
+    opacity: opacityRef,
+    noEsriData,
+    esriTimesteps,
+    getEsriTimeSteps,
+    updateEsriTimeRange,
+    updateEsriOpacity,
+    addEsriSource,
+  };
+}

--- a/src/esri/maplibre/useEsriImageLayer.ts
+++ b/src/esri/maplibre/useEsriImageLayer.ts
@@ -1,0 +1,162 @@
+import { ref, watch, Ref, MaybeRef, toRef, nextTick } from 'vue';
+import { renderingRule, fetchEsriTimeSteps, extractTimeSteps, VariableNames } from '../ImageLayerConfig';
+import { Map } from 'maplibre-gl';
+
+import { ImageService } from 'mapbox-gl-esri-sources';
+
+
+interface UseEsriLayer {
+  esriImageSource: Ref<maplibregl.RasterTileSource | null>;
+  opacity: Ref<number>;
+  noEsriData: Ref<boolean>;
+  esriTimesteps: Ref<number[]>;
+  getEsriTimeSteps: () => void;
+  updateEsriOpacity: (value?: number | null | undefined) => void;
+  updateEsriTimeRange: () => void;
+  addEsriSource: (Map) => void;
+}
+
+export function useEsriLayer(url: string, variableName: VariableNames, timestamp: Ref<number>, opacity: MaybeRef<number>): UseEsriLayer {
+
+  const esriLayerId = 'esri-source';
+  const esriImageSource = ref<maplibregl.RasterTileSource | null>(null);
+  const map = ref<Map | null>(null);
+
+  const esriTimesteps = ref([] as number[]);
+  const opacityRef = toRef(opacity);
+  const noEsriData = ref(false);
+  
+  const options = {
+    'format': 'png',
+    'pixelType': 'U8',
+    'size': '256,256',
+    'transparent': true,
+    'bboxSR': 3857,
+    'imageSR': 3857,
+    'bbox': '{bbox-epsg-3857}',
+    'interpolation': 'RSP_NearestNeighbor',
+    'renderingRule': renderingRule,
+  };
+  const _esriImageOptions = Object.entries(options).map(([key, value]) => `${key}=${value}`).join('&');
+  
+  function addLayer(map: Map | null | undefined) {
+
+    if (map && !map.getLayer(esriLayerId)) {
+      map.addLayer({
+        id: esriLayerId,
+        type: 'raster',
+        source: esriLayerId,
+        paint: {
+          'raster-resampling': 'nearest',
+          'raster-opacity': opacityRef.value ?? 0.8,
+        },
+      });
+    }
+  }
+  
+  function removeLayer(map: Map | null | undefined) {
+    if (map && map.getLayer(esriLayerId)) {
+      map.removeLayer(esriLayerId);
+    }
+  }
+  
+  const dynamicMapService = ref<ImageService | null>(null);
+      
+  
+  function addEsriSource(_map: Map) {
+    if (!_map) return;
+    map.value = _map;
+    
+    dynamicMapService.value = new ImageService(
+      esriLayerId,
+      _map,
+      {
+        url: url,
+        ...options
+      },
+      {
+        tileSize: 256,
+      }
+    );
+
+
+    
+    addLayer(_map);
+  }
+  
+
+  
+  function updateEsriTimeRange() {
+    if (!map.value) return;
+
+    const time = timestamp.value;
+
+    const nearest = esriTimesteps.value.length > 0 
+      ? esriTimesteps.value.reduce((a, b) => Math.abs(b - time) < Math.abs(a - time) ? b : a)
+      : time - 1000 * 60 * 15; 
+    noEsriData.value = Math.abs((nearest - time) / (1000 * 60)) > 60;
+    noEsriData.value = nearest > 1752595200000;
+    if (noEsriData.value) {
+      console.error('No ESRI data available for the selected time');
+    }
+
+    if (dynamicMapService.value && !noEsriData.value) {
+      dynamicMapService.value.setDate(new Date(nearest), new Date(nearest * 2));
+    } else if (!noEsriData.value) {
+      // if there is esri coverage, then this is the issue
+      console.error('Dynamic Map Service is not initialized');
+    }
+  }
+  
+  async function getEsriTimeSteps() {
+    fetchEsriTimeSteps(url, variableName)
+      .then((json) => {
+        esriTimesteps.value = extractTimeSteps(json);
+      }).then(() => {
+        nextTick(updateEsriTimeRange);
+      }).catch((error) => {
+        console.error('Error fetching ESRI time steps:', error);
+      });
+  }
+  
+
+
+  watch(timestamp, (_value) => {
+    updateEsriTimeRange();
+  });
+
+  
+  
+  function updateEsriOpacity(value: number | null | undefined = undefined) {
+    if (map.value) {
+      map.value.setPaintProperty(esriLayerId, 'raster-opacity', value ?? opacityRef.value ?? 0.8);
+    }
+  }
+
+
+  watch(opacityRef, (_value: number) => {
+    updateEsriOpacity(_value);
+  });
+
+  watch(noEsriData, (value: boolean) => {
+    if (value) {
+      updateEsriOpacity(0);
+      removeLayer(map.value as Map | null);
+    } else {
+      addLayer(map.value as Map | null);
+    }
+  });
+
+  return {
+    esriImageSource,
+    opacity: opacityRef,
+    noEsriData,
+    esriTimesteps,
+    getEsriTimeSteps,
+    updateEsriOpacity,
+    updateEsriTimeRange,
+    addEsriSource,
+  } as UseEsriLayer;
+}
+
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -467,6 +467,18 @@
   resolved "https://registry.yarnpkg.com/@soda/get-current-script/-/get-current-script-1.0.2.tgz#a53515db25d8038374381b73af20bb4f2e508d87"
   integrity sha512-T7VNNlYVM1SgQ+VsMYhnDkcGmWhQdL0bDyGm5TlQ3GBXnJscEClUUOKduWTmm2zCnvNLC1hc3JpuXjs/nFOc5w==
 
+"@terraformer/arcgis@^2.1.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@terraformer/arcgis/-/arcgis-2.1.2.tgz#9e05cc5e0ddc400e532f6ccb1d91bdf420e4a756"
+  integrity sha512-IvdfqehcNAUtKU1OFMKwPT8EvdKlVFZ7q7ZKzkIF8XzYZIVsZLuXuOS1UBdRh5u/o+X5Gax7jiZhD8U/4TV+Jw==
+  dependencies:
+    "@terraformer/common" "^2.1.2"
+
+"@terraformer/common@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@terraformer/common/-/common-2.1.2.tgz#7bf83f81f1c3a99069c714c044004f9707f00c97"
+  integrity sha512-cwPdTFzIpekZhZRrgDEkqLKNPoqbyCBQHiemaovnGIeUx0Pl336MY/eCxzJ5zXkrQLVo9zPalq/vYW5HnyKevQ==
+
 "@trysound/sax@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
@@ -525,6 +537,13 @@
   dependencies:
     "@types/estree" "*"
     "@types/json-schema" "*"
+
+"@types/esri-leaflet@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/esri-leaflet/-/esri-leaflet-3.0.3.tgz#14c67eaac6e5dc47a4e7b1d74f97c988580d587b"
+  integrity sha512-trg5D2xqYITp3X6WAGSZ1cRWZz3qkbMkc+6zaiPNOE+klauKEVWfBDExcS96abbXxeUz2DWJ6iZ/A5nkeUVk4g==
+  dependencies:
+    "@types/leaflet" "*"
 
 "@types/estree@*", "@types/estree@^1.0.8":
   version "1.0.8"
@@ -604,7 +623,7 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
-"@types/leaflet@^1.9.11":
+"@types/leaflet@*", "@types/leaflet@^1.9.11":
   version "1.9.20"
   resolved "https://registry.yarnpkg.com/@types/leaflet/-/leaflet-1.9.20.tgz#a7feef4b0a4b36335dfc98456e76c0a86ab8462c"
   integrity sha512-rooalPMlk61LCaLOvBF2VIf9M47HgMQqi5xQ9QRi7c8PkdIe0WrIi5IxXUXQjAdL0c+vcQ01mYWbthzmp9GHWw==
@@ -2516,6 +2535,14 @@ esrecurse@^4.3.0:
   dependencies:
     estraverse "^5.2.0"
 
+esri-leaflet@^3.0.17:
+  version "3.0.17"
+  resolved "https://registry.yarnpkg.com/esri-leaflet/-/esri-leaflet-3.0.17.tgz#b415a65a17e00fa91266efe29fc3386a8d0dd530"
+  integrity sha512-YBJ0n6qmO6rL+GAfCOBngmClvrZILDerGhK92ibcA47QTE6VVzkshFpe6KcSX/RdM6rS1cROld6fHNNhmTAL2w==
+  dependencies:
+    "@terraformer/arcgis" "^2.1.0"
+    tiny-binary-search "^1.0.3"
+
 estraverse@^4.1.1:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
@@ -3690,6 +3717,11 @@ make-dir@^3.0.2, make-dir@^3.1.0:
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
   dependencies:
     semver "^6.0.0"
+
+mapbox-gl-esri-sources@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/mapbox-gl-esri-sources/-/mapbox-gl-esri-sources-0.0.7.tgz#8c95e11e548219044bf9075c336d730dbaf38e1f"
+  integrity sha512-fGicRrkoduXvuNSmZH9TG9emxSMaPGZYWYQo5wjc3mjejKThOcHLdkXONnqVXTu7Uyih1FGiij6/e2zqRDIdiQ==
 
 maplibre-gl@^5.5.0:
   version "5.6.1"
@@ -5386,6 +5418,11 @@ thunky@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
+
+tiny-binary-search@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-binary-search/-/tiny-binary-search-1.0.3.tgz#9d52e3d16dd1171eb74486caf704ba08c0c62186"
+  integrity sha512-STSHX/L5nI9WTLv6wrzJbAPbO7OIISX83KFBh2GVbX1Uz/vgZOU/ANn/8iV6t35yMTpoPzzO+3OQid3mifE0CA==
 
 tinyqueue@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This PR builds on top of #122 adding in Esri ImageServer support. 

- `leaflet` support comes from the `esri/esri-leaflet` library. 
- `maplibre` support comes from the `frontiersi/mapbox-gl-esri-sources` library, but can also be created with out the library (as seen in `useEsriImageLayerPlain.ts`. 
  - The library will abort showing an image if we skip passed it's time. When not using it, as you scroll through time, you will see the image continually change it is catches up with itself.

You can see what to uncomment to show the Esri layer in on of the commits

URLs for different data products can be found at 
- [Ozone](https://gis.earthdata.nasa.gov/image/rest/services/C2930764281-LARC_CLOUD/TEMPO_O3TOT_L3_V03_HOURLY_OZONE_COLUMN_AMOUNT/ImageServer)
- [NO2](https://gis.earthdata.nasa.gov/image/rest/services/C2930763263-LARC_CLOUD/TEMPO_NO2_L3_V03_HOURLY_TROPOSPHERIC_VERTICAL_COLUMN/ImageServer)
- [HCHO](https://gis.earthdata.nasa.gov/image/rest/services/C2930761273-LARC_CLOUD/TEMPO_HCHO_L3_V03_HOURLY_VERTICAL_COLUMN/ImageServer)

Currently the `renderingRule` is setup for only NO2, and it does not update the colorbar. These can be setup pretty easily though