### PR TITLE
Properly capitalize TEMPO in page titles

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,9 +16,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://projects.cosmicds.cfa.harvard.edu/vue-ds-template/">
-  <meta property="og:title" content="Tempo Lite">
-  <meta property="og:description" content="Tempo Lite">
-  <meta property="og:site_name" content="Tempo Lite">
+  <meta property="og:title" content="TEMPO Lite">
+  <meta property="og:description" content="TEMPO Lite">
+  <meta property="og:site_name" content="TEMPO Lite">
   <meta property="og:image" content="https://projects.cosmicds.cfa.harvard.edu/vue-ds-template/preview.png">
   <meta property="og:image:secure_url" content="https://projects.cosmicds.cfa.harvard.edu/vue-ds-template/preview.png">
   <meta property="og:image:type" content="image/jpeg">
@@ -35,7 +35,7 @@
   <link rel="apple-touch-icon" sizes="114x114" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon-114.png">
   <link rel="apple-touch-icon" sizes="144x144" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon-144.png">
   <link rel="shortcut icon" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon.ico">
-  <meta name="apple-mobile-web-app-title" content="Tempo Lite">
+  <meta name="apple-mobile-web-app-title" content="TEMPO Lite">
   <link rel="manifest" href="site.webmanifest">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css"/>
   <title>Tempo Lite</title>

--- a/public/index.html.aws
+++ b/public/index.html.aws
@@ -16,9 +16,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://projects.cosmicds.cfa.harvard.edu/vue-ds-template/">
-  <meta property="og:title" content="Tempo Lite">
-  <meta property="og:description" content="Tempo Lite">
-  <meta property="og:site_name" content="Tempo Lite">
+  <meta property="og:title" content="TEMPO Lite">
+  <meta property="og:description" content="TEMPO Lite">
+  <meta property="og:site_name" content="TEMPO Lite">
   <meta property="og:image" content="https://projects.cosmicds.cfa.harvard.edu/vue-ds-template/preview.png">
   <meta property="og:image:secure_url" content="https://projects.cosmicds.cfa.harvard.edu/vue-ds-template/preview.png">
   <meta property="og:image:type" content="image/jpeg">
@@ -35,7 +35,7 @@
   <link rel="apple-touch-icon" sizes="114x114" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon-114.png">
   <link rel="apple-touch-icon" sizes="144x144" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon-144.png">
   <link rel="shortcut icon" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon.ico">
-  <meta name="apple-mobile-web-app-title" content="Tempo Lite">
+  <meta name="apple-mobile-web-app-title" content="TEMPO Lite">
   <link rel="manifest" href="site.webmanifest">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css"/>
   <title>Tempo Lite</title>

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,4 +1,4 @@
 {
   "name": "Cosmic Data Stories: Tempo Lite",
-  "short_name": "Tempo Lite"
+  "short_name": "TEMPO Lite"
 }

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,4 +1,4 @@
 {
-  "name": "Cosmic Data Stories: Tempo Lite",
+  "name": "Cosmic Data Stories: TEMPO Lite",
   "short_name": "TEMPO Lite"
 }


### PR DESCRIPTION
The template that we use to create new vue stories uses title case for capitalization for page titles. This fixes the pages to use all-caps.